### PR TITLE
add option --wallpaper-command

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,12 @@ pub struct Config {
     /// Satpaper will output to a file called "satpaper_latest.png" at this path.
     #[arg(short, long, env = "SATPAPER_TARGET_PATH")]
     pub target_path: PathBuf,
+    /// Command to run to change the wallpaper.
+    ///
+    /// If left empty, it will default to the proper commands for GNOME and KDE.
+    /// The command will be ran as `bash -c "{wallpaper_command} {image_path}"`
+    #[arg(short, long, env = "SATPAPER_WALLPAPER_COMMAND")]
+    pub wallpaper_command: Option<String>,
 }
 
 #[derive(Debug, Copy, Clone, ValueEnum)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,8 +54,10 @@ async fn update_wallpaper() -> Result<()> {
             ).await?;
 
             wallpaper::set(
-                config.target_path.join(OUTPUT_NAME)
-            ).await?;
+                config.target_path.join(OUTPUT_NAME),
+                config.wallpaper_command.as_deref(),
+            )
+            .await?;
 
             log::info!("New wallpaper composited and set.");
         }


### PR DESCRIPTION
This allows to use 'feh' to set the wallpaper on unsupported desktop environnements.