### PR TITLE
Add Windows Support

### DIFF
--- a/src/wallpaper.rs
+++ b/src/wallpaper.rs
@@ -74,7 +74,7 @@ async fn set_gnome(path: &str) -> Result<()> {
 
 async fn set_windows(path: &str) -> Result<()> {
     // From https://c-nergy.be/blog/?p=15291
-    //! IMPORTANT - DO NOT CHANGE THE FORMATTING OF THE POWERSHELL SCRIPT
+    //! IMPORTANT - DO NOT CHANGE THE FORMATTING OF THE POWERSHELL SCRIPT as this will BREAK the script. [more info: https://github.com/PowerShell/PowerShell/issues/2337]
     let powershell_script = format!(
         r#"
 $code = @'

--- a/src/wallpaper.rs
+++ b/src/wallpaper.rs
@@ -74,6 +74,7 @@ async fn set_gnome(path: &str) -> Result<()> {
 
 async fn set_windows(path: &str) -> Result<()> {
     // From https://c-nergy.be/blog/?p=15291
+    //! IMPORTANT - DO NOT CHANGE THE FORMATTING OF THE POWERSHELL SCRIPT
     let powershell_script = format!(
         r#"
 $code = @'

--- a/src/wallpaper.rs
+++ b/src/wallpaper.rs
@@ -1,7 +1,6 @@
-use std::path::Path;
+use anyhow::{Context, Result};
 use std::env;
-
-use anyhow::{Result, Context};
+use std::path::Path;
 use tokio::process::Command;
 
 pub async fn set(path: impl AsRef<Path>, user_command: Option<&str>) -> Result<()> {
@@ -10,19 +9,28 @@ pub async fn set(path: impl AsRef<Path>, user_command: Option<&str>) -> Result<(
         .to_str()
         .context("Failed to convert wallpaper path to a UTF-8 string")?;
 
-    let desktop = env::var("XDG_CURRENT_DESKTOP")
-        .context("Failed to get XDG_CURRENT_DESKTOP environment variable")?;
-    
-    log::debug!("XDG_CURRENT_DESKTOP is {desktop}.");
+    let os = env::consts::OS;
+
     log::debug!("Setting wallpaper to image at path {path}.");
 
-    match user_command {
-        Some(command) => set_userdefined(path, command).await?,
-        None => match desktop.as_str() {
-            "GNOME" => set_gnome(path).await?,
-            "KDE" => set_kde(path).await?,
-            _ => panic!("Desktop {desktop} is not supported."),
-        },
+    match os {
+        "linux" => {
+            let desktop = env::var("XDG_CURRENT_DESKTOP")
+                .context("Failed to get XDG_CURRENT_DESKTOP environment variable")?;
+
+            match user_command {
+                Some(command) => set_userdefined(path, command).await?,
+                None => match desktop.as_str() {
+                    "GNOME" => set_gnome(path).await?,
+                    "KDE" => set_kde(path).await?,
+                    _ => panic!("Desktop {desktop} is not supported."),
+                },
+            }
+        }
+        "windows" => {
+            set_windows(path).await?;
+        }
+        _ => panic!("Operating system not supported."),
     }
 
     Ok(())
@@ -40,18 +48,14 @@ async fn set_userdefined(path: &str, command: &str) -> Result<()> {
 
 async fn set_gnome(path: &str) -> Result<()> {
     let color_scheme = Command::new("gsettings")
-        .args([
-            "get",
-            "org.gnome.desktop.interface",
-            "color-scheme"
-        ])
+        .args(["get", "org.gnome.desktop.interface", "color-scheme"])
         .output()
         .await
         .context("Failed to get preferred color scheme from GSettings")?;
 
     let uri = match String::from_utf8(color_scheme.stdout)?.trim() {
         "'prefer-dark'" => "picture-uri-dark",
-        _ => "picture-uri"
+        _ => "picture-uri",
     };
 
     Command::new("gsettings")
@@ -68,6 +72,46 @@ async fn set_gnome(path: &str) -> Result<()> {
     Ok(())
 }
 
+async fn set_windows(path: &str) -> Result<()> {
+    // From https://c-nergy.be/blog/?p=15291
+    let powershell_script = format!(
+        r#"
+$code = @'
+using System.Runtime.InteropServices;
+namespace Win32 {{
+    public class Wallpaper {{
+        [DllImport("user32.dll", CharSet=CharSet.Auto)]
+        static extern int SystemParametersInfo (int uAction, int uParam, string lpvParam, int fuWinIni);
+
+        public static void SetWallpaper(string thePath) {{
+            SystemParametersInfo(20, 0, thePath, 3);
+        }}
+    }}
+}}
+'@
+
+add-type $code
+
+# Apply the Change on the system
+[Win32.Wallpaper]::SetWallpaper("{}")"#,
+        path
+    );
+
+    Command::new("powershell")
+        .args([
+            "-ExecutionPolicy",
+            "Bypass",
+            "-NoProfile",
+            "-Command",
+            &powershell_script,
+        ])
+        .output()
+        .await
+        .context("PowerShell failed to update wallpaper")?;
+
+    Ok(())
+}
+
 async fn set_kde(path: &str) -> Result<()> {
     // From https://superuser.com/questions/488232
     Command::new("qdbus")
@@ -75,7 +119,8 @@ async fn set_kde(path: &str) -> Result<()> {
             "org.kde.plasmashell",
             "/PlasmaShell",
             "org.kde.PlasmaShell.evaluateScript",
-            &format!(r#"'
+            &format!(
+                r#"'
                 var allDesktops = desktops();
                 print (allDesktops);
                 for (i=0;i<allDesktops.length;i++) {{
@@ -86,7 +131,8 @@ async fn set_kde(path: &str) -> Result<()> {
                                                 "General");
                     d.writeConfig("Image", "file://{path}")
                 }}
-        '"#)
+        '"#
+            ),
         ])
         .output()
         .await


### PR DESCRIPTION
This hacky PowerShell script implementation adds support for Windows.
Although the formatting of the script is ugly, please do NOT CHANGE the formatting of the script, otherwise the script will break!

(Also I just noticed that my code formatting rules might not adhere to the previous code formatting rules, I do apologize for that!)

I tested this on my Windows 11 and Windows 10 machine, and it seems to work fine :)

