### PR TITLE
Added basic support for choosing the product and sector of imagery from the configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ There are several satellites to choose from, each covering a different region of
 - Meteosat 9 (Africa, Middle East, India, Central Asia)
 - Meteosat 10 (Atlantic Ocean, Africa, Europe)
 
+For each satellite, you can select a "sector" and a "product". The sector determines which part of the planet to zoom in on (defaults to 'full_disk', which is the entire Earth), and the product determines how the various black-and-white sensors are combined to produce the final image. The default is 'geocolor', which is an approximation of visible light, with some enhancement at night.
+
 It's also possible to specify a custom background image, if desired.
 
 ## Warning - Data Usage
@@ -74,6 +76,8 @@ Description=Run Satpaper on login.
 Environment=SATPAPER_SATELLITE=goes-east
 Environment=SATPAPER_RESOLUTION_X=2560
 Environment=SATPAPER_RESOLUTION_Y=1440
+Environment=SATPAPER_PRODUCT=geocolor
+Environment=SATPAPER_SECTOR=full_disk
 Environment=SATPAPER_DISK_SIZE=94
 Environment=SATPAPER_TARGET_PATH=/var/home/colonial/.local/share/backgrounds/
 
@@ -120,6 +124,10 @@ launchctl start $HOME/Library/LaunchAgents/com.satpaper.plist
         <string>2560</string>
         <key>SATPAPER_RESOLUTION_Y</key>
         <string>1440</string>
+        <key>SATPAPER_PRODUCT</key>
+        <string>geocolor</string>
+        <key>SATPAPER_SECTOR</key>
+        <string>full_disk</string>
         <key>SATPAPER_DISK_SIZE</key>
         <string>94</string>
         <key>SATPAPER_TARGET_PATH</key>

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       dockerfile: ./docker/Dockerfile
     environment:
       - SATPAPER_SATELLITE=goes-east
+      - SATPAPER_PRODUCT=geocolor
+      - SATPAPER_SECTOR=full_disk
       - SATPAPER_RESOLUTION_X=2560
       - SATPAPER_RESOLUTION_Y=1440
       - SATPAPER_DISK_SIZE=95

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,15 @@ pub struct Config {
     /// The Y resolution/height of the generated wallpaper.
     #[arg(short = 'y', long, env = "SATPAPER_RESOLUTION_Y")]
     pub resolution_y: u32,
+
+    /// The product requested. (geocolor, etc)
+    #[arg(short = 'p', long, env = "SATPAPER_PRODUCT", default_value = "geocolor")]
+    pub product: String,
+
+    /// The sector requested. (full_disk, conus, etc)
+    #[arg(short = 'c', long, env = "SATPAPER_SECTOR", default_value = "full_disk")]
+    pub sector: String,
+
     /// The size of the "disk" (Earth) relative to the generated wallpaper's
     /// smaller dimension.
     /// 
@@ -102,8 +111,8 @@ impl Satellite {
         }
     }
 
-    pub fn tile_image(self) -> Image<Box<[u8]>, 3> {
-        Image::alloc(self.tile_size(), self.tile_size()).boxed()
+    pub fn tile_image(self, sector: &String) -> Image<Box<[u8]>, 3> {
+        Image::alloc(self.tile_size(sector), self.tile_size(sector)).boxed()
     }
 
     pub fn tile_count(self) -> u32 {
@@ -115,13 +124,27 @@ impl Satellite {
         }
     }
 
-    pub fn tile_size(self) -> u32 {
+    pub fn tile_size(self, sector: &String) -> u32 {
         use Satellite::*;
 
         match self {
-            GOESEast | GOESWest => 678,
-            Himawari => 688,
-            Meteosat9 | Meteosat10 => 464,
+            GOESEast | GOESWest => match sector.as_str() {
+                "full_disk" => 678,
+                "conus" => 625,
+                "mesoscale_01" => 500,
+                "mesoscale_02" => 500,
+                _ => 678
+            },
+            Himawari => match sector.as_str() {
+                "full_disk" => 688,
+                "japan" => 750,
+                "mesoscale_01" => 500,
+                _ => 688
+            },
+            Meteosat9 | Meteosat10 =>  match sector.as_str() {
+                "full_disk" => 464,
+                _ => 464
+            },
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,8 @@ mod tests {
             satellite: Satellite::GOESEast,
             resolution_x: 2556,
             resolution_y: 1440,
+            product: "geocolor",
+            sector: "full_disk",
             disk_size: 95,
             target_path: ".".into(),
             wallpaper_command: None,


### PR DESCRIPTION
I just found this project and loved the idea! But I also wanted to see if I could choose which products and sectors from the imagery to use. I saw that this was the [one open issue on the repo, #23. So I took a stab at implementing it.

I will note that this is the first time I have _ever_ looked at a piece of Rust code, so it's entirely possible that I've done something dumb here, and I welcome any comments. But it does seem to work for me at least.

It moves some constants to be optional parameters (with the old values as defaults), and updates the tile size calculation to account for the fact that different sectors have different tile sizes. (I pulled those numbers from the javascript on the SLIDER website.)

There's still a small issue with, for instance, the `conus` sector. The data isn't square like `full_disk`, and so it arrives with black bars on the top/bottom. I don't fully understand how the program is doing the cropping/resizing/compositing, so I haven't tried to fix that yet. Plus at least in my case, it doesn't really matter, since I just center the wallpaper and the margins go off-screen. But it would be nice to be able to output the image at the right aspect ratio.

Also, it would be nice to add some validity checks on the names of the sectors and products. They vary by which satellite you choose of course. Right now if you choose an invalid option, the web request just fails with a 404.

Hopefully this can help folks!