### PR TITLE
feat: make the refresh interval configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Environment=SATPAPER_RESOLUTION_X=2560
 Environment=SATPAPER_RESOLUTION_Y=1440
 Environment=SATPAPER_DISK_SIZE=94
 Environment=SATPAPER_TARGET_PATH=/var/home/colonial/.local/share/backgrounds/
+Environment=SATPAPER_SLEEP_DURATION=60
 
 ExecStart=/var/home/colonial/.cargo/bin/satpaper
 Restart=on-failure
@@ -124,6 +125,8 @@ launchctl start $HOME/Library/LaunchAgents/com.satpaper.plist
         <string>94</string>
         <key>SATPAPER_TARGET_PATH</key>
         <string>/Users/${YOUR_USERNAME}/.local/share/backgrounds/</string>
+        <key>SATPAPER_SLEEP_DURATION</key>
+        <string>60</string>
     </dict>
     <key>ProgramArguments</key>
     <array>
@@ -177,6 +180,7 @@ Thanks to `cyberbit`, everything you need to build and run a Satpaper Docker ima
 - `-w`/`--wallpaper-command`/`SATPAPER_WALLPAPER_COMMAND` - custom command to run when a wallpaper is generated.
     - This overrides the automatic update handling.
     - The command will be run as `sh -c "{command} file://{image_path}"`.
+- `--sleep-duration`/`SATPAPER_SLEEP_DURATION` - seconds between checks for new imagery (default: `60`; must be positive).
 - `-o`/`--once`/`SATPAPER_ONCE` - whether or not to only run once.
     - By default, Satpaper is designed to run as a daemon - it stays resident once launched and periodically attempts to update your wallpaper.
     - With `--once` set, Satpaper will generate one wallpaper and terminate, without altering your existing wallpaper.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,5 +9,6 @@ services:
       - SATPAPER_RESOLUTION_X=2560
       - SATPAPER_RESOLUTION_Y=1440
       - SATPAPER_DISK_SIZE=95
+      - SATPAPER_SLEEP_DURATION=60
     volumes:
       - ../images:/home/rust/images

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,17 +7,17 @@ use fimg::Image;
 #[command(author, version, about, long_about = None)]
 pub struct Config {
     /// The satellite to source imagery from.
-    /// 
+    ///
     /// Options include:
-    /// 
+    ///
     /// - GOES East (covers most of North and South America)
-    /// 
+    ///
     /// - GOES West (Pacific Ocean and parts of the western US)
-    /// 
+    ///
     /// - Himawari (Oceania and East Asia)
-    /// 
+    ///
     /// - Meteosat 9 (Africa, Middle East, India, Central Asia)
-    /// 
+    ///
     /// - Meteosat 10 (Atlantic Ocean, Africa, Europe)
     #[arg(short, long, env = "SATPAPER_SATELLITE")]
     pub satellite: Satellite,
@@ -29,34 +29,42 @@ pub struct Config {
     pub resolution_y: u32,
     /// The size of the "disk" (Earth) relative to the generated wallpaper's
     /// smaller dimension.
-    /// 
+    ///
     /// Values in the 90-95 range are the best if you want maximum detail.
     #[arg(short, long, value_parser = clap::value_parser!(u32).range(1..=100), env = "SATPAPER_DISK_SIZE")]
     pub disk_size: u32,
     /// Where generated wallpapers should be saved.
-    /// 
+    ///
     /// Satpaper will output to a file called "satpaper_latest.png" at this path.
     #[arg(short, long, env = "SATPAPER_TARGET_PATH")]
     pub target_path: PathBuf,
     /// Command to run to change the wallpaper. This overrides automatic update handling.
-    /// 
-    /// The command will be ran as `sh -c "{wallpaper_command} file://{path}"`. 
+    ///
+    /// The command will be ran as `sh -c "{wallpaper_command} file://{path}"`.
     #[arg(short, long, env = "SATPAPER_WALLPAPER_COMMAND")]
     pub wallpaper_command: Option<String>,
+    /// The number of seconds to wait between checks for new satellite imagery.
+    #[arg(
+        long,
+        env = "SATPAPER_SLEEP_DURATION",
+        default_value_t = 60,
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    pub sleep_duration: u64,
     /// Whether or not to only run once.
-    /// 
+    ///
     /// By default, Satpaper is designed to run in the background - it stays resident once launched
     /// and periodically attempts to update your wallpaper.
-    /// 
+    ///
     /// With --once set, Satpaper will instead generate one wallpaper and terminate, without
     /// affecting your existing wallpaper or staying resident.
-    /// 
+    ///
     /// This is ideal if you want to use Satpaper as a simple wallpaper generator or as part of a larger script/program.
     #[arg(short, long, env = "SATPAPER_ONCE", default_value_t = false)]
     pub once: bool,
     /// A background image to use instead of the default pure black.
-    /// 
-    /// For best results, the image should match the specified resolution, 
+    ///
+    /// For best results, the image should match the specified resolution,
     /// but Satpaper will resize the image to fit if need be.
     #[arg(short, long, env = "SATPAPER_BACKGROUND_IMAGE")]
     pub background_image: Option<PathBuf>,
@@ -89,7 +97,7 @@ impl Satellite {
             GOESWest => "goes-18",
             Himawari => "himawari",
             Meteosat9 => "meteosat-9",
-            Meteosat10 => "meteosat-0deg"
+            Meteosat10 => "meteosat-0deg",
         }
     }
 
@@ -123,5 +131,47 @@ impl Satellite {
             Himawari => 688,
             Meteosat9 | Meteosat10 => 464,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn required_args() -> Vec<&'static str> {
+        vec![
+            "satpaper",
+            "--satellite",
+            "goes-east",
+            "--resolution-x",
+            "1920",
+            "--resolution-y",
+            "1080",
+            "--disk-size",
+            "95",
+            "--target-path",
+            ".",
+        ]
+    }
+
+    #[test]
+    fn sleep_duration_uses_default_and_cli_override() {
+        let config = Config::try_parse_from(required_args()).unwrap();
+        assert_eq!(config.sleep_duration, 60);
+
+        let mut args = required_args();
+        args.extend(["--sleep-duration", "300"]);
+        let config = Config::try_parse_from(args).unwrap();
+        assert_eq!(config.sleep_duration, 300);
+    }
+
+    #[test]
+    fn sleep_duration_rejects_zero() {
+        let mut args = required_args();
+        args.extend(["--sleep-duration", "0"]);
+
+        let error = Config::try_parse_from(args).unwrap_err();
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,7 @@ mod config;
 mod slider;
 mod wallpaper;
 
-use std::time::Duration;
-use std::thread::sleep;
+use std::{thread::sleep, time::Duration};
 
 use anyhow::{Result, Context};
 use clap::Parser;
@@ -13,7 +12,6 @@ use clap::Parser;
 use crate::config::*;
 
 const OUTPUT_NAME: &str = "satpaper_latest.png";
-const SLEEP_DURATION: Duration = Duration::from_secs(60);
 
 fn main() -> Result<()> {
     if std::env::var("RUST_LOG").is_err() {
@@ -30,6 +28,7 @@ fn main() -> Result<()> {
 
 fn update_wallpaper() -> Result<()> {
     let config = Config::parse();
+    let sleep_duration = Duration::from_secs(config.sleep_duration);
     
     let mut timestamp = None;
     
@@ -66,9 +65,9 @@ fn update_wallpaper() -> Result<()> {
             }
         }
 
-        log::debug!("Sleeping for {SLEEP_DURATION:?}...");
+        log::debug!("Sleeping for {sleep_duration:?}...");
 
-        sleep(SLEEP_DURATION);
+        sleep(sleep_duration);
     }
 
     #[allow(unreachable_code)]
@@ -88,8 +87,9 @@ mod tests {
             disk_size: 95,
             target_path: ".".into(),
             wallpaper_command: None,
+            sleep_duration: 60,
             once: false,
-            background_image: None
+            background_image: None,
         };
 
         slider::composite_latest_image(&config)?;


### PR DESCRIPTION
## Summary

Allow users to reduce Satpaper's bandwidth usage by configuring how long it waits between checks for new imagery.

The new `--sleep-duration`/`SATPAPER_SLEEP_DURATION` setting is expressed in seconds, defaults to `60`, and rejects zero.

## Changes

- add a positive `u64` sleep-duration CLI and environment setting
- convert the configured seconds to a `Duration` once when the update loop starts
- document the setting in the options reference
- add the setting to the systemd, launchd, and Docker Compose examples
- cover the default, CLI override, and zero-value rejection

## Testing

- [x] `cargo test --release -- --skip generate_wallpaper` — 3 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `git diff --check`

Closes #28
